### PR TITLE
Remove duplicated email link

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,7 +1,4 @@
 <section id="social-pane" class="row text-center social">
-  {{ with .Site.Params.social.email }}
-  <a href="mailto:{{.}}" aria-label="Email"><i class="fas fa-envelope" aria-hidden="true"></i></a>
-  {{ end }}
   {{ with .Site.Params.social.twitter }}
   <a href="https://twitter.com/{{.}}" aria-label="Twitter" target="_blank"><i class="fab fa-twitter" aria-hidden="true"></i></a>
   {{ end }}


### PR DESCRIPTION
Email link is duplicated at the begin and end of the social row